### PR TITLE
文字列を反転させる処理をSkypeMessageクラスに実装とテスト追加

### DIFF
--- a/src/main/java/jp/co/gxp/bot/skype/domain/skype/SkypeMessage.java
+++ b/src/main/java/jp/co/gxp/bot/skype/domain/skype/SkypeMessage.java
@@ -22,8 +22,8 @@ public class SkypeMessage {
      * メッセージを反転した新しいSkypeMessageオブジェクトを戻します
      * @return SkypeMessage
      */
-    public SkypeMessage getReverseMessage() {
-        StringBuffer sb = new StringBuffer(this.getValue());
+    public SkypeMessage createReverseMessage() {
+        StringBuffer sb = new StringBuffer(this.value);
         String reverseString = sb.reverse().toString();
         return new SkypeMessage(reverseString);
     }

--- a/src/main/java/jp/co/gxp/bot/skype/domain/skype/SkypeMessage.java
+++ b/src/main/java/jp/co/gxp/bot/skype/domain/skype/SkypeMessage.java
@@ -17,4 +17,14 @@ public class SkypeMessage {
     public String getValue() {
         return value;
     }
+
+    /**
+     * メッセージを反転した新しいSkypeMessageオブジェクトを戻します
+     * @return SkypeMessage
+     */
+    public SkypeMessage getReverseMessage() {
+        StringBuffer sb = new StringBuffer(this.getValue());
+        String reverseString = sb.reverse().toString();
+        return new SkypeMessage(reverseString);
+    }
 }

--- a/src/main/java/jp/co/gxp/bot/skype/domain/skype/SkypeRoomDefined.java
+++ b/src/main/java/jp/co/gxp/bot/skype/domain/skype/SkypeRoomDefined.java
@@ -7,7 +7,7 @@ import jp.co.gxp.bot.skype.util.validator.ApiRequestEnum;
  * idはルームで{@code /get name}を行うことで取得可能
  */
 public enum SkypeRoomDefined implements ApiRequestEnum, SkypeRoom {
-    TEST("test", "19:97dfc589f33342b3baece09dd3acba0a@thread.skype"); // FIXME 使うルームIDに修正すること
+    TEST("test", "19:fe3ac3bb9efd4a84a68a5313f85903fb@thread.skype"); // FIXME 使うルームIDに修正すること
     
     private String apiValue;
     private String id;

--- a/src/main/java/jp/co/gxp/bot/skype/repository/skype/SkypeBotApiRepository.java
+++ b/src/main/java/jp/co/gxp/bot/skype/repository/skype/SkypeBotApiRepository.java
@@ -19,6 +19,7 @@ import org.springframework.web.client.RestOperations;
 import jp.co.gxp.bot.skype.domain.base.SkypeApiException;
 import jp.co.gxp.bot.skype.domain.skype.SkypeBotApiAccessToken;
 import jp.co.gxp.bot.skype.domain.skype.SkypeMessage;
+import jp.co.gxp.bot.skype.domain.skype.SkypeRoom;
 import jp.co.gxp.bot.skype.domain.skype.SkypeRoomDefined;
 import jp.co.gxp.bot.skype.domain.skype.SkypeRoomUndefined;
 
@@ -105,8 +106,7 @@ public class SkypeBotApiRepository implements SkypeBotRepository {
      * @param message     メッセージ
      */
     @Override
-    public void postMessage(SkypeBotApiAccessToken accessToken, SkypeRoomDefined room, SkypeMessage message) {
-
+    public void postMessage(SkypeBotApiAccessToken accessToken, SkypeRoom room, SkypeMessage message) {
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Bearer " + accessToken.getValue());
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -131,32 +131,4 @@ public class SkypeBotApiRepository implements SkypeBotRepository {
             throw new SkypeApiException("post message is failed :" + e.getMessage());
         }
     }
-
-	@Override
-	public void postMessage(SkypeBotApiAccessToken accessToken, SkypeRoomUndefined room, SkypeMessage message) {
-		// TODO 自動生成されたメソッド・スタブ
-		HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "Bearer " + accessToken.getValue());
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
-        SkypeBotApiPostRequest json = new SkypeBotApiPostRequest(message);
-        HttpEntity<SkypeBotApiPostRequest> request = new HttpEntity<>(json, headers);
-
-        String url = "https://api.skype.net/v3/conversations/{room_id}/activities/";
-
-        try {
-            ResponseEntity<String> response = restOperations.postForEntity(url, request, String.class, room.getId());
-            logger.info("post message result : " + response.getStatusCode().toString());
-            logger.debug("header : " + response.getHeaders().toString());
-            logger.debug("body : " + response.getBody());
-        } catch (HttpClientErrorException e) {
-            logger.error("post message is failed by : " + e.getMessage());
-            logger.error("header : " + e.getResponseHeaders().toString());
-            logger.error("body : " + e.getResponseBodyAsString());
-            throw new SkypeApiException("post message is failed :" + e.getMessage());
-        } catch (RestClientException e) {
-            logger.error(e.toString());
-            throw new SkypeApiException("post message is failed :" + e.getMessage());
-        }
-	}
 }

--- a/src/main/java/jp/co/gxp/bot/skype/repository/skype/SkypeBotRepository.java
+++ b/src/main/java/jp/co/gxp/bot/skype/repository/skype/SkypeBotRepository.java
@@ -2,6 +2,7 @@ package jp.co.gxp.bot.skype.repository.skype;
 
 import jp.co.gxp.bot.skype.domain.skype.SkypeBotApiAccessToken;
 import jp.co.gxp.bot.skype.domain.skype.SkypeMessage;
+import jp.co.gxp.bot.skype.domain.skype.SkypeRoom;
 import jp.co.gxp.bot.skype.domain.skype.SkypeRoomDefined;
 import jp.co.gxp.bot.skype.domain.skype.SkypeRoomUndefined;
 
@@ -13,8 +14,6 @@ public interface SkypeBotRepository {
 
     SkypeBotApiAccessToken auth();
 
-    void postMessage(SkypeBotApiAccessToken accessToken, SkypeRoomDefined room, SkypeMessage message);
 
-    void postMessage(SkypeBotApiAccessToken accessToken, SkypeRoomUndefined room, SkypeMessage message);
-
+    void postMessage(SkypeBotApiAccessToken accessToken, SkypeRoom room, SkypeMessage message);
 }

--- a/src/main/java/jp/co/gxp/bot/skype/service/BotWorkService.java
+++ b/src/main/java/jp/co/gxp/bot/skype/service/BotWorkService.java
@@ -18,7 +18,7 @@ public class BotWorkService {
 	public void makeMessage(SkypeBotApiAccessToken token, SkypeRoomUndefined room, SkypeMessage message) {
 		// トークン生成
 		SkypeBotApiAccessToken accessToken = skypeBotRepository.auth();
-        skypeBotRepository.postMessage(accessToken, room, message.getReverseMessage());
+        skypeBotRepository.postMessage(accessToken, room, message.createReverseMessage());
 	}
 
 }

--- a/src/main/java/jp/co/gxp/bot/skype/service/BotWorkService.java
+++ b/src/main/java/jp/co/gxp/bot/skype/service/BotWorkService.java
@@ -14,21 +14,11 @@ public class BotWorkService {
 	@Autowired
 	private SkypeBotRepository skypeBotRepository;
 
-	private void postMessage(SkypeBotApiAccessToken token, SkypeRoomUndefined room, SkypeMessage message) {
-
-		skypeBotRepository.postMessage(token, room, message);
-	}
 
 	public void makeMessage(SkypeBotApiAccessToken token, SkypeRoomUndefined room, SkypeMessage message) {
-
-		// 文字列を反転させて返すよ
-		StringBuffer sb = new StringBuffer(message.getValue());
-		String newMessage = sb.reverse().toString();
-
 		// トークン生成
 		SkypeBotApiAccessToken accessToken = skypeBotRepository.auth();
-
-		this.postMessage(accessToken, room, new SkypeMessage(newMessage));
+        skypeBotRepository.postMessage(accessToken, room, message.getReverseMessage());
 	}
 
 }

--- a/src/main/java/jp/co/gxp/bot/skype/service/SkypeMessagePostService.java
+++ b/src/main/java/jp/co/gxp/bot/skype/service/SkypeMessagePostService.java
@@ -16,7 +16,7 @@ public class SkypeMessagePostService {
     @Autowired
     private SkypeBotRepository skypeBotRepository;
     
-    public void postMessage(SkypeRoom room, SkypeMessage message) {
+    public void postMessage(SkypeRoomDefined room, SkypeMessage message) {
         SkypeBotApiAccessToken accessToken = skypeBotRepository.auth();
         skypeBotRepository.postMessage(accessToken, room, message);
     }

--- a/src/main/java/jp/co/gxp/bot/skype/service/SkypeMessagePostService.java
+++ b/src/main/java/jp/co/gxp/bot/skype/service/SkypeMessagePostService.java
@@ -2,6 +2,7 @@ package jp.co.gxp.bot.skype.service;
 
 import jp.co.gxp.bot.skype.domain.skype.SkypeBotApiAccessToken;
 import jp.co.gxp.bot.skype.domain.skype.SkypeMessage;
+import jp.co.gxp.bot.skype.domain.skype.SkypeRoom;
 import jp.co.gxp.bot.skype.domain.skype.SkypeRoomDefined;
 import jp.co.gxp.bot.skype.repository.skype.SkypeBotRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +16,7 @@ public class SkypeMessagePostService {
     @Autowired
     private SkypeBotRepository skypeBotRepository;
     
-    public void postMessage(SkypeRoomDefined room, SkypeMessage message) {
+    public void postMessage(SkypeRoom room, SkypeMessage message) {
         SkypeBotApiAccessToken accessToken = skypeBotRepository.auth();
         skypeBotRepository.postMessage(accessToken, room, message);
     }

--- a/src/test/java/jp/co/gxp/bot/skype/domain/skype/SkypeMessageTest.java
+++ b/src/test/java/jp/co/gxp/bot/skype/domain/skype/SkypeMessageTest.java
@@ -15,9 +15,9 @@ public class SkypeMessageTest {
      * 文字列が判定できていることを期待するテスト
      */
     @Test
-    public void test() throws Exception {
+    public void test() {
         SkypeMessage skypeMessage = new SkypeMessage("test");
-        SkypeMessage reverseSkypeMessage = skypeMessage.getReverseMessage();
+        SkypeMessage reverseSkypeMessage = skypeMessage.createReverseMessage();
         assertThat("tset", is(reverseSkypeMessage.getValue()));
     }
 

--- a/src/test/java/jp/co/gxp/bot/skype/domain/skype/SkypeMessageTest.java
+++ b/src/test/java/jp/co/gxp/bot/skype/domain/skype/SkypeMessageTest.java
@@ -1,0 +1,24 @@
+//
+//
+package jp.co.gxp.bot.skype.domain.skype;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class SkypeMessageTest {
+
+
+    /**
+     * 文字列が判定できていることを期待するテスト
+     */
+    @Test
+    public void test() throws Exception {
+        SkypeMessage skypeMessage = new SkypeMessage("test");
+        SkypeMessage reverseSkypeMessage = skypeMessage.getReverseMessage();
+        assertThat("tset", is(reverseSkypeMessage.getValue()));
+    }
+
+}

--- a/src/test/java/jp/co/gxp/bot/skype/repository/skype/SkypeBotApiRepositoryTest.java
+++ b/src/test/java/jp/co/gxp/bot/skype/repository/skype/SkypeBotApiRepositoryTest.java
@@ -2,7 +2,10 @@ package jp.co.gxp.bot.skype.repository.skype;
 
 import jp.co.gxp.bot.skype.domain.skype.SkypeBotApiAccessToken;
 import jp.co.gxp.bot.skype.domain.skype.SkypeMessage;
+import jp.co.gxp.bot.skype.domain.skype.SkypeRoom;
 import jp.co.gxp.bot.skype.domain.skype.SkypeRoomDefined;
+import jp.co.gxp.bot.skype.domain.skype.SkypeRoomUndefined;
+
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,4 +28,13 @@ public class SkypeBotApiRepositoryTest {
         skypeBotRepository.postMessage(accessToken, SkypeRoomDefined.TEST, message);
     }
     
+    @Ignore
+    @Test
+    public void postTest2() {
+        SkypeMessage message = new SkypeMessage("test");
+        SkypeRoomUndefined skypeRoomUndefined = new SkypeRoomUndefined("");
+        SkypeBotApiAccessToken accessToken = skypeBotRepository.auth();
+        skypeBotRepository.postMessage(accessToken, skypeRoomUndefined, message);
+    }
+
 }


### PR DESCRIPTION
postMessageメソッドを共通化するために、引数をインタフェースに変更